### PR TITLE
Adjusted recipes to support the ore dictionary entries for sticks and…

### DIFF
--- a/src/main/resources/assets/astikorcarts/recipes/cargocart.json
+++ b/src/main/resources/assets/astikorcarts/recipes/cargocart.json
@@ -11,7 +11,8 @@
       "ore": "plankWood"
     },
     "c": {
-      "item": "minecraft:chest"
+      "type": "forge:ore_dict",
+      "ore": "chestWood"
     },
     "w": {
       "item": "astikorcarts:wheel"

--- a/src/main/resources/assets/astikorcarts/recipes/plowcart.json
+++ b/src/main/resources/assets/astikorcarts/recipes/plowcart.json
@@ -11,7 +11,8 @@
       "ore": "plankWood"
     },
     "s": {
-      "item": "minecraft:stick"
+      "type": "forge:ore_dict",
+      "ore": "stickWood"
     },
     "w": {
       "item": "astikorcarts:wheel"

--- a/src/main/resources/assets/astikorcarts/recipes/wheel.json
+++ b/src/main/resources/assets/astikorcarts/recipes/wheel.json
@@ -11,7 +11,8 @@
       "ore": "plankWood"
     },
     "s": {
-      "item": "minecraft:stick"
+      "type": "forge:ore_dict",
+      "ore": "stickWood"
     }
   },
   "result": {


### PR DESCRIPTION
… chests.

This helps when using mods like Charset - Storage or similar that modify the existing recipes for chests.  If no mods exist that adjust these, the recipes still work.